### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wasix-tests
-Some testcases that worked on my machine
+Some test cases that worked on my machine
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- fix README wording to use "test cases" spelling
- ensure newline at EOF

## Testing
- `bash test.sh` *(fails: Test extern-variable failed, Test helloworld failed, Test minimal-threadlocal failed, Test simple-dynamic-lib failed, Test simple-shared-lib failed, Test static-libc++ failed, Test weak-symbol-undefined failed)*