### PR TITLE
docs: mention WASIX_SYSROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,18 @@ Some testcases that worked on my machine
 
 ## Running tests
 
-Run `bash test.sh`
+Before running tests, ensure that the environment variable `WASIX_SYSROOT` is set
+to the path of your WASIX installation. The Makefiles rely on this variable to
+find the correct sysroot. Once set, run the tests with:
+
+```bash
+bash test.sh
+```
 
 ## Adding tests
 
-Run `bash create-test.sh`
+Before creating a new test, export `WASIX_SYSROOT` as described above and then run:
+
+```bash
+bash create-test.sh
+```


### PR DESCRIPTION
## Summary
- explain how to set `WASIX_SYSROOT` when running or adding tests

## Testing
- `bash test.sh` *(fails: WASIX_SYSROOT missing)*