### PR TITLE
Fix minimal-threadlocal stdout expectation

### DIFF
--- a/minimal-threadlocal/test.sh
+++ b/minimal-threadlocal/test.sh
@@ -9,5 +9,5 @@ if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.l
     assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
 fi
 
-assert_eq "Hello, World!" "$(cat stdout.log)" "stdout did not match expected value"
+assert_eq $'hello\ndestruct thread local' "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"


### PR DESCRIPTION
## Summary
- fix expected stdout in minimal-threadlocal test

## Testing
- `bash test.sh` *(fails: clang and WASIX toolchain not installed)*