### PR TITLE
Improve repo documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,31 @@
 # some testcases for wasix
 
-Before working on this repo, verify that you can execute tests. `bash test.sh` in the root should suffice. Below is a list of tests that are currently broken. Fixing them most likely involves changes in wasix-libc or wasmer, which is not in the scope of this repo. In case they do get fix, or new broken tests are added, please leave a note in this file. If you change something about the structure of the repo or the build infra, update this file.
+Before working on this repo, verify that you can execute the tests. Run `bash test.sh` in the root directory.  The individual test directories contain Makefiles that expect **clang‑19** and **clang++‑19** and a working WASIX sysroot.  Set the environment variable `WASIX_SYSROOT` to the sysroot path of your WASIX installation before invoking any Makefiles.  Without it the builds will fail.
 
-Please update this file with detailed instructions for everything, that will affect the next agent or human.
+All tests are executed with `wasmer` by default.  You can override the binary by setting the `WASMER` environment variable.
 
-TODO: Write instructions on how to inspect generated wasm (For example with `wasm-tools print FILE | head -n30`)
+Below is a list of tests that are currently known to be broken.  Fixing them most likely involves changes in `wasix-libc` or `wasmer`, which is out of scope for this repository.  If you notice that a broken test starts passing (or a new test breaks) please update this file.  Also update this file if you change the repository structure or the build infrastructure.
+
+Please update this file with detailed instructions for everything that will affect the next agent or human.
+
+### Inspecting generated WebAssembly
+
+If you need to look at the produced WebAssembly files (e.g. `*.wasm`, `*.o`, `*.so`)
+you can convert them to the text format using the `wasm-tools` package:
+
+```bash
+wasm-tools print FILE | head -n 30
+```
+
+`wasm2wat` from `wabt` works as well.  This is often useful when debugging relocation problems.
+
 TODO: Improve this file
 
 ## Notes
+
+`bash test.sh` currently fails in this environment because no WASIX sysroot is
+available.  Once a valid sysroot is provided via `WASIX_SYSROOT` the tests
+should build and run (with the exceptions listed below).
 
 Tests that are currently broken:
 - `minimal-threadlocal`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # wasix-tests
-Some testcases that worked on my machine
+
+Collection of small C/C++ test cases for the [WASIX](https://github.com/wasix-org) toolchain.
+Each test lives in its own directory with a `Makefile` and a `test.sh` script.
+
+## Requirements
+
+* `clang-19` and `clang++-19`
+* a WASIX sysroot – set the `WASIX_SYSROOT` environment variable to its path
+* [`wasmer`](https://github.com/wasmerio/wasmer) (override with `WASMER` env var)
+* `wasm-tools` or `wabt` (optional, for inspecting generated modules)
 
 ## Running tests
 
-Run `bash test.sh`
+1. Ensure `WASIX_SYSROOT` points to your WASIX installation.
+2. Execute `bash test.sh` in the repository root.  The script iterates over all
+   subdirectories and invokes their individual `test.sh` files.
+3. Use `bash clean.sh` to remove build artefacts.
+
+You may also run the `test.sh` inside a specific test directory to build and run
+just that test.
 
 ## Adding tests
 
-Run `bash create-test.sh`
+Run `bash create-test.sh <new-test-name>` to create a new test directory based on
+the `helloworld` example.  Adjust the generated files as necessary.


### PR DESCRIPTION
## Summary
- elaborate repo instructions in README
- document test prerequisites and wasm inspection commands in AGENTS.md
- clarify that WebAssembly files may use suffixes other than .wasm

## Testing
- `bash test.sh` *(fails: WASIX_SYSROOT not set)*