### PR TITLE
Unify test scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,15 @@ Please update this file with detailed instructions for everything, that will aff
 TODO: Write instructions on how to inspect generated wasm (For example with `wasm-tools print FILE | head -n30`)
 TODO: Improve this file
 
+All test scripts source `../lib/test-utils.sh` which provides `build_targets` and
+`run_wasm` helper functions.
+
+If `tput` fails while sourcing `lib/assert.sh` (e.g. because `$TERM` is unset),
+export `TERM=xterm` before running the tests.
+
 ## Notes
 
 Tests that are currently broken:
 - `minimal-threadlocal`
 - `extern-threadlocal-nopic`
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Some test cases that worked on my machine
 
 Before running tests, ensure that the environment variable `WASIX_SYSROOT` is set
 to the path of your WASIX installation. The Makefiles rely on this variable to
-find the correct sysroot. Once set, run the tests with:
+find the correct sysroot. If `tput` errors appear when running the tests, export
+`TERM=xterm` to provide a basic terminal description. Once the environment is
+configured, run the tests with:
 
 ```bash
 bash test.sh

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
 
 for makefile in ./*/Makefile; do
     makedir=$(dirname "$makefile")
@@ -6,3 +8,4 @@ for makefile in ./*/Makefile; do
     make -C "$makedir" clean || true
     echo "--------------------------------"
 done
+

--- a/create-test.sh
+++ b/create-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
-# This script is used to create a test directory for the given test name. Copies from helloworld and takes a new name as first parameter.
+# This script is used to create a test directory for the given test name.
+# Copies from helloworld and takes a new name as first parameter.
 
 # Check if test name is provided
 if [ $# -eq 0 ]; then
@@ -30,8 +32,9 @@ fi
 echo "Creating test directory: $TEST_NAME"
 cp -r "$TEMPLATE_DIR" "$DEST_DIR"
 
-# Replace occurrences of "helloworld" with the new test name in key files
+# Replace occurrences of \"helloworld\" with the new test name in key files
 find "$DEST_DIR" -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "Makefile" -o -name "*.toml" \) -exec sed -i "s/helloworld/$TEST_NAME/g" {} \;
 mv "$DEST_DIR/helloworld.c" "$DEST_DIR/$TEST_NAME.c"
 
 echo "Test directory '$TEST_NAME' created successfully."
+

--- a/extern-threadlocal-nopic/test.sh
+++ b/extern-threadlocal-nopic/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq "error number: 999" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/extern-threadlocal/test.sh
+++ b/extern-threadlocal/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq "error number: 999" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/extern-variable/test.sh
+++ b/extern-variable/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq "error number: 444" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/helloworld/test.sh
+++ b/helloworld/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make helloworld.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) helloworld.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets helloworld.wasm
+run_wasm helloworld.wasm
 
 assert_eq "Hello, World!" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/lib/assert.sh
+++ b/lib/assert.sh
@@ -20,11 +20,11 @@
 #####################################################################
 
 if command -v tput &>/dev/null && tty -s; then
-  RED=$(tput setaf 1)
-  GREEN=$(tput setaf 2)
-  MAGENTA=$(tput setaf 5)
-  NORMAL=$(tput sgr0)
-  BOLD=$(tput bold)
+  RED=$(tput setaf 1 2>/dev/null || echo -en "\e[31m")
+  GREEN=$(tput setaf 2 2>/dev/null || echo -en "\e[32m")
+  MAGENTA=$(tput setaf 5 2>/dev/null || echo -en "\e[35m")
+  NORMAL=$(tput sgr0 2>/dev/null || echo -en "\e[00m")
+  BOLD=$(tput bold 2>/dev/null || echo -en "\e[01m")
 else
   RED=$(echo -en "\e[31m")
   GREEN=$(echo -en "\e[32m")

--- a/lib/test-utils.sh
+++ b/lib/test-utils.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build all targets passed as arguments
+build_targets() {
+    make "$@"
+}
+
+# Run the specified wasm file using wasmer
+run_wasm() {
+    local wasm_file="$1"
+    if ! ${WASMER:-wasmer} run --mapdir /lib:$(pwd) "$wasm_file" \
+        > stdout.log 2> stderr.log; then
+        assert_eq 0 "$?" "wasmer run failed: $(cat stderr.log)"
+    fi
+}
+

--- a/minimal-threadlocal/test.sh
+++ b/minimal-threadlocal/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq $'hello\ndestruct thread local' "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/simple-dynamic-lib/test.sh
+++ b/simple-dynamic-lib/test.sh
@@ -2,13 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make libside.so
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets libside.so main.wasm
+run_wasm main.wasm
 
 assert_eq "The dynamic library returned: 42" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/simple-shared-lib/test.sh
+++ b/simple-shared-lib/test.sh
@@ -2,13 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make libside.so
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets libside.so main.wasm
+run_wasm main.wasm
 
 assert_eq "The shared library returned: 42" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/static-libc++/test.sh
+++ b/static-libc++/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq "Hello, World!" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
 
 for testfile in ./*/test.sh; do
     testdir=$(dirname "$testfile")
@@ -12,3 +14,4 @@ for testfile in ./*/test.sh; do
     fi
     echo "--------------------------------"
 done
+

--- a/weak-symbol-undefined/test.sh
+++ b/weak-symbol-undefined/test.sh
@@ -2,12 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 source ../lib/assert.sh
+source ../lib/test-utils.sh
 
-make main.wasm
-
-if ${WASMER:-wasmer} run --mapdir /lib:$(pwd) main.wasm > stdout.log 2> stderr.log ; then : ; else
-    assert_eq 0 $? "wasmer run failed: $(cat stderr.log)"
-fi
+build_targets main.wasm
+run_wasm main.wasm
 
 assert_eq "success: other_func is NULL, which is expected" "$(cat stdout.log)" "stdout did not match expected value"
 assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"
+


### PR DESCRIPTION
## Summary
- add helper script for building and running wasm tests
- use new helpers across all test folders
- tidy root helper scripts and AGENTS instructions
- document TERM environment note

## Testing
- `bash test.sh` *(fails: clang not found / WASIX_SYSROOT not set)*