### PR TITLE
Improve debugging guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ wasm-tools print FILE | head -n 30
 
 TODO: Improve this file
 
+### Debugging failing tests
+
+If you encounter a failing test and need guidance on how to debug it, see
+`docs/debugging-tests.md` for a walkthrough. The document explains how to run
+individual test suites, increase build verbosity, and inspect generated
+WebAssembly files.
+
 All test scripts source `../lib/test-utils.sh` which provides `build_targets` and
 `run_wasm` helper functions.
 

--- a/docs/debugging-tests.md
+++ b/docs/debugging-tests.md
@@ -1,0 +1,70 @@
+# Debugging Failing Tests
+
+This document outlines a process for investigating and resolving failing WASIX tests.
+It assumes the toolchain is installed as described in `README.md` and that the environment
+variables `WASIX_SYSROOT` and `WASMER` (optional) are set appropriately.
+
+## 1. Reproduce the Failure
+
+Start by running the tests to see the failure output. From the repository root:
+
+```bash
+bash test.sh
+```
+
+Check the last lines of the output. Look for the test name and any error messages. Ensure
+`WASIX_SYSROOT` points to a valid sysroot. Without it, all builds fail with a `Please set WASIX_SYSROOT` message.
+
+## 2. Build a Single Test
+
+To isolate a test, change into its directory and run `bash test.sh`. Example:
+
+```bash
+cd helloworld
+bash test.sh
+```
+
+This script compiles the test using `make` and then runs the produced module with `wasmer`.
+If compilation fails, inspect the `*.o` and `*.wasm` files using `wasm-tools print` or
+`wasm2wat` to confirm that expected symbols are present.
+
+## 3. Increase Verbosity
+
+The Makefiles in this repository already print the compiler and linker commands
+as they execute.  Passing `V=1` has no additional effect.  If you need even more
+details, you can temporarily enable shell tracing in a `test.sh` script by
+adding `set -x` near the top.
+
+## 4. Run Under a Debugger
+
+`wasmer` supports `--debug` and `--invoke` flags. For the most detailed runtime
+traces, set the environment variable `WASMER_LOG=trace` before invoking the
+test binary.  `wasmtime` may also be useful if available.
+
+```bash
+WASMER_LOG=trace wasmer run test.wasm
+```
+
+Look for traps or missing imports. In some cases, enabling `set -x` in the `test.sh` script can
+help trace the commands being executed.
+
+## 5. Compare with a Working Test
+
+If a similar test passes, diff its `Makefile` and source files against the failing one. Small
+configuration differences (e.g. `-shared` vs. `-static` or `-fPIC` flags) can lead to subtle
+linking or runtime issues.
+
+## 6. Consult the WASIX Documentation
+
+This repository does not include local WASIX manuals. If the failure seems
+related to the runtime or the standard library, check the upstream WASIX
+project and the `wasmer` README for information about supported features and
+required runtime flags. Some functionality may still be experimental or need
+specific command-line options.
+
+## 7. Update Documentation
+
+After identifying the root cause and fixing the test, update `AGENTS.md` with any changes that
+will assist future contributors. Document new environment variables, required tools, or anything
+that deviates from the default workflow.
+


### PR DESCRIPTION
## Summary
- clarify that V=1 does nothing in our Makefiles
- suggest WASMER_LOG=trace for the most verbose runtime logs
- note that WASIX docs must be read upstream

## Testing
- `bash test.sh` *(fails: Please set WASIX_SYSROOT)*