### PR TITLE
Add compiler wrappers and update tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,15 @@
 # some testcases for wasix
 
-Before working on this repo, verify that you can execute the tests. Run `bash test.sh` in the root directory.  The individual test directories contain Makefiles that expect **clang‑19** and **clang++‑19** and a working WASIX sysroot.  Set the environment variable `WASIX_SYSROOT` to the sysroot path of your WASIX installation before invoking any Makefiles.  Without it the builds will fail.
+Before working on this repo, verify that you can execute the tests. Run `bash test.sh` in the root directory.  The individual test directories expect a WASIX sysroot and the compiler wrappers found in `scripts/`.  Set `WASIX_SYSROOT` accordingly and prepend the `scripts/` directory to your `PATH`:
+
+```bash
+export WASIX_SYSROOT=/wasix-sysroot
+export PATH="$(pwd)/scripts:$PATH"
+# choose which toolchain to test
+export CC=wasix-clang CXX=wasix-clang++ LD=wasix-clang
+```
+
+Use `emscripten-clang`/`emscripten-clang++` for Emscripten builds.
 
 All tests are executed with `wasmer` by default.  You can override the binary by setting the `WASMER` environment variable.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Each test lives in its own directory with a `Makefile` and a `test.sh` script.
 ## Requirements
 
 * `clang-19` and `clang++-19`
+* `emcc` and `em++` (for Emscripten builds)
 * a WASIX sysroot – set the `WASIX_SYSROOT` environment variable to its path
 * [`wasmer`](https://github.com/wasmerio/wasmer) (override with `WASMER` env var)
 * `wasm-tools` or `wabt` (optional, for inspecting generated modules)
@@ -14,15 +15,27 @@ Each test lives in its own directory with a `Makefile` and a `test.sh` script.
 
 Run `bash scripts/setup-wasix.sh` once to install the toolchain, then execute
 `bash test.sh`. Ensure `WASIX_SYSROOT=/wasix-sysroot` is set in the environment.
+Before running any `make` files, prepend the repository's `scripts/` directory
+to your `PATH` and select which wrapper to use:
+
+```bash
+# WASIX build
+export PATH="$(pwd)/scripts:$PATH"
+export CC=wasix-clang CXX=wasix-clang++ LD=wasix-clang
+```
+
+For an Emscripten build use `emscripten-clang`/`emscripten-clang++` instead.
 
 Alternatively:
 
 1. Ensure `WASIX_SYSROOT` points to your WASIX installation.
-2. If `tput` errors appear when running the tests, export `TERM=xterm` to provide
-   a basic terminal description.
-3. Execute `bash test.sh` in the repository root.  The script iterates over all
+2. Prepend `scripts/` to `PATH` and set `CC`, `CXX`, and `LD` to the desired
+   wrapper (`wasix-clang` or `emscripten-clang`).
+3. If `tput` errors appear when running the tests, export `TERM=xterm` to
+   provide a basic terminal description.
+4. Execute `bash test.sh` in the repository root.  The script iterates over all
    subdirectories and invokes their individual `test.sh` files.
-3. Use `bash clean.sh` to remove build artefacts.
+5. Use `bash clean.sh` to remove build artefacts.
 
 You may also run the `test.sh` inside a specific test directory to build and run
 just that test.

--- a/extern-threadlocal-nopic/Makefile
+++ b/extern-threadlocal-nopic/Makefile
@@ -1,26 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang++-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+=-pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+=-fno-trapping-math 
-CFLAGS+=-D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--extra-features=atomics,--extra-features=bulk-memory,--extra-features=mutable-globals
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 %.o: %.cpp Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@

--- a/extern-threadlocal/Makefile
+++ b/extern-threadlocal/Makefile
@@ -1,36 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+= -pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+= -fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+= -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+= -fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--extra-features=atomics,--extra-features=bulk-memory,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--export-all
-# Export all libc symbols
-LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 
 %.o: %.cpp Makefile

--- a/extern-variable/Makefile
+++ b/extern-variable/Makefile
@@ -1,34 +1,9 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+= -pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+= -fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+= -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+= -fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--extra-features=atomics,--extra-features=bulk-memory,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--export-all
 # Export all libc symbols
 MAIN_LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lc++,-lc++abi,-lpthread,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
 

--- a/helloworld/Makefile
+++ b/helloworld/Makefile
@@ -1,41 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+= -pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+= -fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+= -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+= -fvisibility=default
-CFLAGS+= -fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export-if-defined=_ZTH5errno
-LDFLAGS+=-Wl,--export-if-defined=__cxa_thread_atexit_impl
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export-all
-LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 %.o: %.c Makefile
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/minimal-threadlocal/Makefile
+++ b/minimal-threadlocal/Makefile
@@ -1,38 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+=-pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+=-fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+=-D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+=-fvisibility=default
-CFLAGS+=-fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export-all
-LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lwasi-emulated-mman,-lwasi-emulated-getpid,-lc++,-lc++abi,--no-whole-archive
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 %.o: %.cpp Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@

--- a/scripts/emscripten-clang
+++ b/scripts/emscripten-clang
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec emcc "$@"

--- a/scripts/emscripten-clang++
+++ b/scripts/emscripten-clang++
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec em++ "$@"

--- a/scripts/wasix-clang
+++ b/scripts/wasix-clang
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${WASIX_SYSROOT:-}" ]; then
+    echo "WASIX_SYSROOT environment variable not set" >&2
+    exit 1
+fi
+
+ARGS=(
+    --target=wasm32-wasi
+    --sysroot="${WASIX_SYSROOT}"
+    -matomics -mbulk-memory -mmutable-globals
+    -pthread -mthread-model posix -ftls-model=local-exec
+    -fno-trapping-math
+    -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS
+    -fvisibility=default -fPIC
+    -Wl,--experimental-pic
+    -Wl,-pie
+    -Wl,--import-memory
+    -Wl,--shared-memory
+    -Wl,--export-if-defined=__wasm_apply_data_relocs
+    -Wl,--export-if-defined=_ZTH5errno
+    -Wl,--export-if-defined=__cxa_thread_atexit_impl
+    -Wl,--export=__wasm_call_ctors
+    -Wl,--extra-features=atomics
+    -Wl,--extra-features=bulk-memory
+    -Wl,--extra-features=mutable-globals
+    -Wl,--export-all
+    -Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
+)
+
+if [[ " $* " == *" -shared "* || " $* " == *" --shared "* ]]; then
+    tmp=()
+    for a in "${ARGS[@]}"; do
+        [[ $a == "-Wl,-pie" ]] && continue
+        tmp+=("$a")
+    done
+    ARGS=("${tmp[@]}")
+fi
+
+exec clang-19 "${ARGS[@]}" "$@"

--- a/scripts/wasix-clang++
+++ b/scripts/wasix-clang++
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${WASIX_SYSROOT:-}" ]; then
+    echo "WASIX_SYSROOT environment variable not set" >&2
+    exit 1
+fi
+
+ARGS=(
+    --target=wasm32-wasi
+    --sysroot="${WASIX_SYSROOT}"
+    -matomics -mbulk-memory -mmutable-globals
+    -pthread -mthread-model posix -ftls-model=local-exec
+    -fno-trapping-math
+    -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS
+    -fvisibility=default -fPIC
+    -Wl,--experimental-pic
+    -Wl,-pie
+    -Wl,--import-memory
+    -Wl,--shared-memory
+    -Wl,--export-if-defined=__wasm_apply_data_relocs
+    -Wl,--export-if-defined=_ZTH5errno
+    -Wl,--export-if-defined=__cxa_thread_atexit_impl
+    -Wl,--export=__wasm_call_ctors
+    -Wl,--extra-features=atomics
+    -Wl,--extra-features=bulk-memory
+    -Wl,--extra-features=mutable-globals
+    -Wl,--export-all
+    -Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
+)
+
+if [[ " $* " == *" -shared "* || " $* " == *" --shared "* ]]; then
+    tmp=()
+    for a in "${ARGS[@]}"; do
+        [[ $a == "-Wl,-pie" ]] && continue
+        tmp+=("$a")
+    done
+    ARGS=("${tmp[@]}")
+fi
+
+exec clang++-19 "${ARGS[@]}" "$@"

--- a/simple-dynamic-lib/Makefile
+++ b/simple-dynamic-lib/Makefile
@@ -1,32 +1,10 @@
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+=-pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+=-fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+=-fPIC
 # This is technically only required for the library
-CFLAGS+=-fvisibility=default
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi -fno-rtlib-defaultlib
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,--shared-memory
 
 MAIN_LDFLAGS=$(LDFLAGS)
 MAIN_LDFLAGS+=-L$(shell pwd)
@@ -36,8 +14,6 @@ MAIN_LDFLAGS+=-Wl,-pie
 MAIN_LDFLAGS+=-Wl,--export-all
 # Export all libc symbols
 MAIN_LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
-
-
 
 SIDE_LDFLAGS=$(LDFLAGS)
 SIDE_LDFLAGS+=--no-standard-libraries -nostdlib++ -Wl,--no-entry

--- a/simple-shared-lib/Makefile
+++ b/simple-shared-lib/Makefile
@@ -1,32 +1,10 @@
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+=-pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+=-fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+=-fPIC
 # This is technically only required for the library
-CFLAGS+=-fvisibility=default
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi -fno-rtlib-defaultlib
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,--shared-memory
 
 MAIN_LDFLAGS=$(LDFLAGS)
 MAIN_LDFLAGS+=-L$(shell pwd)
@@ -36,7 +14,6 @@ MAIN_LDFLAGS+=-Wl,-pie
 MAIN_LDFLAGS+=-Wl,--export-all
 # Export all libc symbols
 MAIN_LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
-
 
 SIDE_LDFLAGS=$(LDFLAGS)
 # Don't link against libc

--- a/static-libc++/Makefile
+++ b/static-libc++/Makefile
@@ -1,41 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+= -pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+= -fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+= -D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+= -fvisibility=default
-CFLAGS+= -fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export-if-defined=_ZTH5errno
-LDFLAGS+=-Wl,--export-if-defined=__cxa_thread_atexit_impl
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lc++,-lc++abi,-lwasi-emulated-mman,-lwasi-emulated-getpid,--no-whole-archive
-LDFLAGS+=-Wl,--export-all
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 %.o: %.cpp Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@

--- a/test.sh
+++ b/test.sh
@@ -5,16 +5,22 @@ cd "$(dirname "$0")"
 # Ensure tput based color output works even in non-interactive environments
 export TERM="${TERM:-xterm-256color}"
 
-for testfile in ./*/test.sh; do
-    testdir=$(dirname "$testfile")
-    testname=$(basename "$testdir")
-    echo "Running test: $testname"
+for tool in wasix emscripten; do
+    echo "### Running $tool tests"
+    export PATH="$(pwd)/scripts:$PATH"
+    export CC="${tool}-clang" CXX="${tool}-clang++" LD="${tool}-clang"
 
-    if bash "$testfile"; then
-        echo "Test $testname passed."
-    else
-        echo "Test $testname failed."
-    fi
-    echo "--------------------------------"
+    for testfile in ./*/test.sh; do
+        testdir=$(dirname "$testfile")
+        testname=$(basename "$testdir")
+        echo "Running test: $testname ($tool)"
+
+        if bash "$testfile"; then
+            echo "Test $testname passed."
+        else
+            echo "Test $testname failed."
+        fi
+        echo "--------------------------------"
+    done
 done
 

--- a/weak-symbol-undefined/Makefile
+++ b/weak-symbol-undefined/Makefile
@@ -1,38 +1,8 @@
-# WASIX_SYSROOT="$(WASIX_SYSROOT)"
-
-ifeq ($(WASIX_SYSROOT),)
-$(error Please set WASIX_SYSROOT to the sysroot path of your WASIX installation)
-endif
 
 WASMER?=wasmer
-CC=clang-19
-CXX=clang++-19
-LD=clang-19
-
-CFLAGS=""
-CFLAGS+=--target=wasm32-wasi
-CFLAGS+=--sysroot="${WASIX_SYSROOT}"
-CFLAGS+=-matomics -mbulk-memory -mmutable-globals
-CFLAGS+=-pthread -mthread-model posix -ftls-model=local-exec
-CFLAGS+=-fno-trapping-math -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL
-CFLAGS+=-D_WASI_EMULATED_PROCESS_CLOCKS
-CFLAGS+=-fvisibility=default
-CFLAGS+=-fPIC
-
-LDFLAGS=""
-LDFLAGS+=--target=wasm32-wasi
-LDFLAGS+=--sysroot="${WASIX_SYSROOT}"
-LDFLAGS+=-Wl,--experimental-pic
-LDFLAGS+=-Wl,-pie
-LDFLAGS+=-Wl,--import-memory
-LDFLAGS+=-Wl,--shared-memory
-LDFLAGS+=-Wl,--export-if-defined=__wasm_apply_data_relocs
-LDFLAGS+=-Wl,--export=__wasm_call_ctors
-LDFLAGS+=-Wl,--extra-features=atomics
-LDFLAGS+=-Wl,--extra-features=bulk-memory
-LDFLAGS+=-Wl,--extra-features=mutable-globals
-LDFLAGS+=-Wl,--export-all
-LDFLAGS+=-Wl,--whole-archive,-lc,-lutil,-lresolv,-lrt,-lm,-lpthread,-lwasi-emulated-mman,-lwasi-emulated-getpid,-lc++,-lc++abi,--no-whole-archive
+CC ?= cc
+CXX ?= c++
+LD ?= cc
 
 %.o: %.cpp Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
## Summary
- add wasix and emscripten compiler wrapper scripts
- simplify Makefiles to rely on generic CC/CXX/LD
- document wrapper usage in README and AGENTS
- run test suite for both WASIX and emscripten
- handle -shared case in wasix wrappers

## Testing
- `bash test.sh` *(fails: WASIX_SYSROOT environment variable not set)*