### PR TITLE
Disable failing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,11 @@ export `TERM=xterm` before running the tests.
 available.  Once a valid sysroot is provided via `WASIX_SYSROOT` the tests
 should build and run (with the exceptions listed below).
 
-Tests that are currently broken:
+Tests that are currently disabled because they fail:
 - `minimal-threadlocal`
 - `extern-threadlocal-nopic`
+
+The top-level `test.sh` script skips these tests.
 
 ## CI notes
 

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@ cd "$(dirname "$0")"
 export TERM="${TERM:-xterm-256color}"
 export WASIX_SYSROOT="${WASIX_SYSROOT:-/wasix-sysroot}"
 
+disabled_tests=("minimal-threadlocal" "extern-threadlocal-nopic")
+
 for tool in wasix emscripten; do
     echo "### Running $tool tests"
     export PATH="$(pwd)/scripts:$PATH"
@@ -14,6 +16,12 @@ for tool in wasix emscripten; do
     for testfile in ./*/test.sh; do
         testdir=$(dirname "$testfile")
         testname=$(basename "$testdir")
+
+        if [[ " ${disabled_tests[@]} " =~ " ${testname} " ]]; then
+            echo "Skipping disabled test: $testname ($tool)"
+            continue
+        fi
+
         echo "Running test: $testname ($tool)"
 
         if bash "$testfile"; then


### PR DESCRIPTION
## Summary
- skip `minimal-threadlocal` and `extern-threadlocal-nopic` in the root `test.sh`
- document that these tests are disabled in `AGENTS.md`

## Testing
- `bash test.sh`