### PR TITLE
Fix runner exit status handling

### DIFF
--- a/lib/test-utils.sh
+++ b/lib/test-utils.sh
@@ -6,8 +6,13 @@ run() {
     RUNNER=${RUNNER:-../lib/wrappers/native-clang-runner}
     local executable="$1"
     shift
-    if ! $RUNNER "./$executable" "$@" > stdout.log 2> stderr.log; then
-        assert_eq 0 "$?" "run failed: $(cat stderr.log)"
+
+    $RUNNER "./$executable" "$@" > stdout.log 2> stderr.log
+    local status=$?
+
+    if [ "$status" -ne 0 ]; then
+        assert_eq 0 "$status" "run failed: $(cat stderr.log)"
+        return "$status"
     fi
 }
 


### PR DESCRIPTION
## Summary
- capture RUNNER's exit status before calling `assert_eq`
- ensure `run()` fails when the invoked program returns non-zero

## Testing
- `bash test.sh` *(fails: 12 passed, 12 failed)*