### PR TITLE
Fix docs for test-utils and emscripten wrapper names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,7 @@ If you encounter a failing test and need guidance on how to debug it, see
 individual test suites, increase build verbosity, and inspect generated
 WebAssembly files.
 
-All test scripts source `../lib/test-utils.sh` which provides `build_targets` and
-`run_wasm` helper functions.
+All test scripts source `../lib/test-utils.sh`, which currently only provides the `run` helper.
 
 If `tput` fails while sourcing `lib/assert.sh` (e.g. because `$TERM` is unset),
 export `TERM=xterm` before running the tests.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ export PATH="$(pwd)/lib/wrappers:$PATH"
 export CC=wasix-clang CXX=wasix-clang++ LD=wasix-clang
 ```
 
-For an Emscripten build use `emscripten-clang`/`emscripten-clang++` instead.
+For an Emscripten build use `emscripten`/`emscripten++` instead.
 
 Alternatively:
 
 1. Ensure `WASIX_SYSROOT` points to your WASIX installation.
 2. Prepend `lib/wrappers/` to `PATH` and set `CC`, `CXX`, and `LD` to the desired
-   wrapper (`wasix-clang` or `emscripten-clang`).
+   wrapper (`wasix-clang` or `emscripten`).
 3. If `tput` errors appear when running the tests, export `TERM=xterm` to
    provide a basic terminal description.
 4. Execute `bash test.sh` in the repository root.  The script iterates over all


### PR DESCRIPTION
## Summary
- clarify that `test-utils.sh` only exposes the `run` helper
- update README instructions for the emscripten wrapper

## Testing
- `bash test.sh` *(fails: undefined symbol in multiple tests)*