### PR TITLE
Fix missing runner error output

### DIFF
--- a/lib/test-utils.sh
+++ b/lib/test-utils.sh
@@ -8,8 +8,10 @@ run() {
     local executable="$1"
     shift
 
+    set +e
     $RUNNER "./$executable" "$@" > stdout.log 2> stderr.log
     local status=$?
+    set -e
 
     if [ "$status" -ne 0 ]; then
         assert_eq 0 "$status" "run failed: $(cat stderr.log)"

--- a/lib/wrappers/emscripten-runner
+++ b/lib/wrappers/emscripten-runner
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 RUNNER="${NODEJS:-node}"
-if ! which "$RUNNER" &>/dev/null; then
-    echo "Node.js not found. Please add node to your PATH or set the 'NODEJS' environment variable."
+if ! command -v "$RUNNER" &>/dev/null; then
+    echo "Node.js not found. Please add node to your PATH or set the 'NODEJS' environment variable." >&2
     exit 1
 fi
 

--- a/lib/wrappers/wasix-clang-runner
+++ b/lib/wrappers/wasix-clang-runner
@@ -3,7 +3,7 @@ set -euo pipefail
 
 RUNNER="${WASMER:-wasmer}"
 if ! command -v "$RUNNER" &>/dev/null; then
-    echo "Wasmer not found. Please add wasmer to your PATH or set the 'WASMER' environment variable."
+    echo "Wasmer not found. Please add wasmer to your PATH or set the 'WASMER' environment variable." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- ensure wrapper error messages go to stderr
- retain exit status in `run` helper even when `set -e` is active

## Testing
- `bash test.sh` *(fails: `emcc: not found`)*