### PR TITLE
Add mmap-anon test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Collection of small C/C++ test cases for the [WASIX](https://github.com/wasix-org) toolchain.
 Each test lives in its own directory with a `Makefile` and a `test.sh` script.
+The `mmap-anon` test demonstrates anonymous memory mapping using `mmap`.
 
 ## Requirements
 

--- a/mmap-anon/Makefile
+++ b/mmap-anon/Makefile
@@ -1,0 +1,6 @@
+include ../lib/common.mk.inc
+
+all: main
+
+main: main.o
+	$(CXX) main.o $(LDFLAGS) $(MAIN_LDFLAGS) -o $@

--- a/mmap-anon/main.c
+++ b/mmap-anon/main.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+int main(void) {
+    size_t size = 4096;
+    char *p = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (p == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+    const char *msg = "mmap anon memory works";
+    strcpy(p, msg);
+    if (strcmp(p, msg) != 0) {
+        fprintf(stderr, "readback mismatch\n");
+        munmap(p, size);
+        return 1;
+    }
+    printf("%s\n", p);
+    if (munmap(p, size) != 0) {
+        perror("munmap");
+        return 1;
+    }
+    return 0;
+}

--- a/mmap-anon/test.sh
+++ b/mmap-anon/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+source ../lib/assert.sh
+source ../lib/test-utils.sh
+
+make main
+run main
+
+assert_eq "mmap anon memory works" "$(cat stdout.log)" "stdout did not match expected value"
+assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"


### PR DESCRIPTION
## Summary
- add new mmap-anon test
- mention mmap-anon test in README

## Testing
- `bash test.sh` *(fails: emcc/em++ missing)*