### PR TITLE
Add dynamic TLS destructor test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,17 @@ You may also run the `test.sh` inside a specific test directory to build and run
 just that test.
 When contributing code, run `bash test.sh` before creating a pull request to verify that all tests still pass.
 
+## Available tests
 
-
+- extern-threadlocal-nopic
+- extern-threadlocal
+- extern-variable
+- helloworld
+- minimal-threadlocal
+- simple-dynamic-lib
+- simple-shared-lib
+- weak-symbol-undefined
+- dynamic-tls-dtor
 
 ## Adding tests
 

--- a/dynamic-tls-dtor/Makefile
+++ b/dynamic-tls-dtor/Makefile
@@ -1,0 +1,14 @@
+include ../lib/common.mk.inc
+
+MAIN_LDFLAGS += -L$(shell pwd)
+MAIN_LDFLAGS += -ltlsdtor
+
+TLS_LDFLAGS += -shared
+
+all: main
+
+main: main.o libtlsdtor.so
+	$(CXX) main.o $(LDFLAGS) $(MAIN_LDFLAGS) -o $@
+
+lib%.so: %.o
+	$(CXX) $< $(LDFLAGS) $(TLS_LDFLAGS) -o $@

--- a/dynamic-tls-dtor/lib.cpp
+++ b/dynamic-tls-dtor/lib.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+struct Item {
+    ~Item() { std::cout << "tls dtor fired\n"; }
+};
+
+extern "C" {
+    thread_local Item tls_item;
+    void use_tls();
+}
+
+thread_local Item tls_item;
+void use_tls() {
+    (void)tls_item;
+}

--- a/dynamic-tls-dtor/main.cpp
+++ b/dynamic-tls-dtor/main.cpp
@@ -1,0 +1,24 @@
+#include <dlfcn.h>
+#include <thread>
+#include <iostream>
+
+int main() {
+    void* handle = dlopen("./libtlsdtor.so", RTLD_NOW);
+    if (!handle) {
+        std::cerr << "dlopen failed: " << dlerror() << std::endl;
+        return 1;
+    }
+
+    using func_t = void (*)();
+    auto use_tls = (func_t)dlsym(handle, "use_tls");
+    if (!use_tls) {
+        std::cerr << "dlsym failed: " << dlerror() << std::endl;
+        return 1;
+    }
+
+    std::thread t([&]{ use_tls(); });
+    t.join();
+
+    dlclose(handle);
+    return 0;
+}

--- a/dynamic-tls-dtor/test.sh
+++ b/dynamic-tls-dtor/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+source ../lib/assert.sh
+source ../lib/test-utils.sh
+
+make libtlsdtor.so main
+run main
+
+assert_eq "tls dtor fired" "$(cat stdout.log)" "destructor did not run"
+assert_eq "" "$(cat stderr.log)" "stderr not empty"
+


### PR DESCRIPTION
## Summary
- add new dynamic-tls-dtor test
- load a shared library defining a thread-local object with destructor
- check that the destructor runs when a spawned thread exits
- document test in README

## Testing
- `bash test.sh` *(fails: em++ not found and no rule for libtlsdtor.so)*