### PR TITLE
Add threadlocal errno test

### DIFF
--- a/threadlocal-errno/Makefile
+++ b/threadlocal-errno/Makefile
@@ -1,0 +1,9 @@
+include ../lib/common.mk.inc
+
+CFLAGS += -pthread
+LDFLAGS += -pthread
+
+all: main
+
+main: main.o
+	$(CXX) main.o $(LDFLAGS) $(MAIN_LDFLAGS) -o $@

--- a/threadlocal-errno/main.cpp
+++ b/threadlocal-errno/main.cpp
@@ -1,0 +1,29 @@
+#include <errno.h>
+#include <stdio.h>
+#include <thread>
+#include <vector>
+
+constexpr int NUM_THREADS = 4;
+int thread_values[NUM_THREADS];
+
+void worker(int idx) {
+    errno = 100 + idx;
+    thread_values[idx] = errno;
+}
+
+int main() {
+    errno = 1;
+    std::vector<std::thread> threads;
+    threads.reserve(NUM_THREADS);
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back(worker, i);
+    }
+    for (auto &t : threads) {
+        t.join();
+    }
+    printf("main errno %d\n", errno);
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        printf("thread %d errno %d\n", i, thread_values[i]);
+    }
+    return 0;
+}

--- a/threadlocal-errno/test.sh
+++ b/threadlocal-errno/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This test should pass with both wasix-clang and native gcc/clang
+set -e
+cd "$(dirname "$0")"
+source ../lib/assert.sh
+source ../lib/test-utils.sh
+
+make main
+run main
+
+expected=$'main errno 1\nthread 0 errno 100\nthread 1 errno 101\nthread 2 errno 102\nthread 3 errno 103'
+assert_eq "$expected" "$(cat stdout.log)" "stdout did not match expected value"
+assert_eq "" "$(cat stderr.log)" "stderr did not match expected value"


### PR DESCRIPTION
## Summary
- add `threadlocal-errno` test directory
- check that errno is thread-local across multiple threads
- provide Makefile and test script

## Testing
- `bash test.sh` *(fails: `wasix-clang` can't link due to missing WASIX sysroot)*