### PR TITLE
Fix dynamic TLS destructor test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,17 @@ You may also run the `test.sh` inside a specific test directory to build and run
 just that test.
 When contributing code, run `bash test.sh` before creating a pull request to verify that all tests still pass.
 
+## Available tests
 
-
+- extern-threadlocal-nopic
+- extern-threadlocal
+- extern-variable
+- helloworld
+- minimal-threadlocal
+- simple-dynamic-lib
+- simple-shared-lib
+- weak-symbol-undefined
+- dynamic-tls-dtor
 
 ## Adding tests
 

--- a/dynamic-tls-dtor/Makefile
+++ b/dynamic-tls-dtor/Makefile
@@ -1,0 +1,17 @@
+include ../lib/common.mk.inc
+
+MAIN_LDFLAGS += -L$(shell pwd)
+MAIN_LDFLAGS += -ltlsdtor
+
+# Position independent code needed for shared library with TLS
+CFLAGS += -fPIC
+
+TLS_LDFLAGS += -shared
+
+all: main
+
+main: main.o libtlsdtor.so
+	$(CXX) main.o $(LDFLAGS) $(MAIN_LDFLAGS) -o $@
+
+lib%.so: %.o
+	$(CXX) $< $(LDFLAGS) $(TLS_LDFLAGS) -o $@

--- a/dynamic-tls-dtor/main.cpp
+++ b/dynamic-tls-dtor/main.cpp
@@ -1,0 +1,24 @@
+#include <dlfcn.h>
+#include <thread>
+#include <iostream>
+
+int main() {
+    void* handle = dlopen("libtlsdtor.so", RTLD_NOW);
+    if (!handle) {
+        std::cerr << "dlopen failed: " << dlerror() << std::endl;
+        return 1;
+    }
+
+    using func_t = void (*)();
+    auto use_tls = (func_t)dlsym(handle, "use_tls");
+    if (!use_tls) {
+        std::cerr << "dlsym failed: " << dlerror() << std::endl;
+        return 1;
+    }
+
+    std::thread t([&]{ use_tls(); });
+    t.join();
+
+    dlclose(handle);
+    return 0;
+}

--- a/dynamic-tls-dtor/test.sh
+++ b/dynamic-tls-dtor/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+source ../lib/assert.sh
+source ../lib/test-utils.sh
+
+make libtlsdtor.so main
+run main
+
+assert_eq "tls dtor fired" "$(cat stdout.log)" "destructor did not run"
+assert_eq "" "$(cat stderr.log)" "stderr not empty"
+

--- a/dynamic-tls-dtor/tlsdtor.cpp
+++ b/dynamic-tls-dtor/tlsdtor.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+struct Item {
+    ~Item() { std::cout << "tls dtor fired\n"; }
+};
+
+thread_local Item tls_item;
+
+extern "C" void use_tls() {
+    (void)tls_item;
+}


### PR DESCRIPTION
## Summary
- rename lib.cpp to tlsdtor.cpp so pattern rule can build libtlsdtor.so
- compile shared library with `-fPIC`
- load library using `dlopen("libtlsdtor.so")`
- update README with dynamic-tls-dtor entry

## Testing
- `bash test.sh` *(fails: emcc not found, thread creation failed under wasix runner)*