### PR TITLE
Update test scripts to use pipefail

### DIFF
--- a/extern-threadlocal-nopic/test.sh
+++ b/extern-threadlocal-nopic/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/extern-threadlocal/test.sh
+++ b/extern-threadlocal/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/extern-variable/test.sh
+++ b/extern-variable/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/helloworld/test.sh
+++ b/helloworld/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/minimal-threadlocal/test.sh
+++ b/minimal-threadlocal/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/mmap-anon/test.sh
+++ b/mmap-anon/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/simple-dynamic-lib/test.sh
+++ b/simple-dynamic-lib/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 
 source ../lib/assert.sh

--- a/simple-shared-lib/test.sh
+++ b/simple-shared-lib/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/threadlocal-errno/test.sh
+++ b/threadlocal-errno/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This test should pass with both wasix-clang and native gcc/clang
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh

--- a/weak-symbol-undefined/test.sh
+++ b/weak-symbol-undefined/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")"
 source ../lib/assert.sh
 source ../lib/test-utils.sh


### PR DESCRIPTION
## Summary
- use `set -euo pipefail` in all sub test scripts

## Testing
- `bash test.sh` *(fails: em++ not found)*